### PR TITLE
options, tryHook wrapper and get_template_vars

### DIFF
--- a/app.py
+++ b/app.py
@@ -28,9 +28,9 @@ def getDevices():
     ]
 
 
-def loadCustomVars(template):
+def loadCustomVars(request):
     return {
-        "template": template,
+        "url": request.url,
         "time" : datetime.now().strftime("%H:%M:%S")
     }
 

--- a/app.py
+++ b/app.py
@@ -28,6 +28,14 @@ def getDevices():
     ]
 
 
+def loadCustomVars(template):
+    return {
+        "template": template,
+        "time" : datetime.now().strftime("%H:%M:%S")
+    }
+
+exampleInstance.registerHook("register_template_vars", loadCustomVars)
+
 exampleInstance.registerHook("get_devices", getDevices)
 
 #data for all pages.  Header & footer info, user control etc..

--- a/readme.md
+++ b/readme.md
@@ -279,3 +279,11 @@ def loadCustomVars(request):
 
 
 ```
+
+# Templating
+
+Every template in the scute default_templates folder can be overriden with your own template placed in a `templates` folder. Each template has the following special scute global variables available:
+
+* systemInfo - anything coming from a `get_system_info` hook
+* scute_options - the options object you initially passed into your app
+* hook_vars - the result of the `register_template_vars` hook for the current request. See [template hooks](#template-hooks).

--- a/readme.md
+++ b/readme.md
@@ -265,15 +265,15 @@ Scripts allow you to run pre-defined command line scripts with input of paramete
 
 ## Template hooks
 
-You may wish to add additional template variables to your templates. There is a `register_template_vars` hook for this purpose. It receives one parameter, the name of the template being rendered, and should return a dictionary. The dictionary returned will be placed in a `vars` object to use in your template.
+You may wish to add additional template variables to your templates. There is a `register_template_vars` hook for this purpose. It receives one parameter, the current Request object, and should return a dictionary. The dictionary returned will be placed in a `vars` object to use in your template.
 
 For example:
 
 ```Python
 
-def loadCustomVars(template):
+def loadCustomVars(request):
     return {
-        "currentTemplate": template,
+        "url": request.url,
         "time" : datetime.now().strftime("%H:%M:%S")
     }
 

--- a/readme.md
+++ b/readme.md
@@ -262,3 +262,20 @@ Scripts allow you to run pre-defined command line scripts with input of paramete
     * Command (string) -  the actual command. Use `${parametername}` to swap out parameters supplied by the user through the interface.
     * Description (string) - A description of the command, shown before it is run
     * Parameters (object) - A list of parameters the user will be able to input, they will be swapped out in the command, the value is the label shown to the user, the key is the actual parameter in the command, `${directory}` for example.
+
+## Template hooks
+
+You may wish to add additional template variables to your templates. There is a `register_template_vars` hook for this purpose. It receives one parameter, the name of the template being rendered, and should return a dictionary. The dictionary returned will be placed in a `vars` object to use in your template.
+
+For example:
+
+```Python
+
+def loadCustomVars(template):
+    return {
+        "currentTemplate": template,
+        "time" : datetime.now().strftime("%H:%M:%S")
+    }
+
+
+```

--- a/scute/__init__.py
+++ b/scute/__init__.py
@@ -21,7 +21,7 @@ class scute:
 
         @flaskServer.context_processor
         def default_vars():
-            return {"systemInfo":self.getSystemInfo(), "scute_options":self.options, "hook_vars":self.tryHook("register_template_vars", request)}
+            return {"systemInfo":self.tryHook("get_system_info"), "scute_options":self.options, "hook_vars":self.tryHook("register_template_vars", request)}
 
         self.options = options
         self.server = flaskServer
@@ -125,9 +125,6 @@ class scute:
             for device in devices:
                 deviceReports[device] = self.getDeviceReport(device)
         return deviceReports
-
-    def getSystemInfo(self):
-        return self.hooks["get_system_info"]()
 
     def getHelpInfo(self):
         helpInfo = {}

--- a/scute/__init__.py
+++ b/scute/__init__.py
@@ -21,7 +21,7 @@ class scute:
 
         @flaskServer.context_processor
         def default_vars():
-            return {"systemInfo":self.getSystemInfo(), "options":self.options, "vars":self.tryHook("register_template_vars", request)}
+            return {"systemInfo":self.getSystemInfo(), "scute_options":self.options, "hook_vars":self.tryHook("register_template_vars", request)}
 
         self.options = options
         self.server = flaskServer

--- a/scute/__init__.py
+++ b/scute/__init__.py
@@ -19,6 +19,10 @@ class scute:
     hooks = {}
     def __init__(self, options, flaskServer):
 
+        @flaskServer.context_processor
+        def default_vars():
+            return {"systemInfo":self.getSystemInfo(), "options":self.options, "vars":self.tryHook("register_template_vars", request)}
+
         self.options = options
         self.server = flaskServer
         my_loader = jinja2.ChoiceLoader([
@@ -137,12 +141,12 @@ class scute:
     def indexView(self):
 
         indexData = {"header": "Welcome To SCUTE", "content": "<a href='/list'>Scan For Devices</a>"}
-        return render_template("content/index.html", title="Welcome", indexData = indexData, systemInfo = self.getSystemInfo(), options=self.options, vars=self.tryHook("register_template_vars", "content/index.html"))
+        return render_template("content/index.html", title="Welcome", indexData = indexData)
 
 
     def deviceListView(self):
         
-        return render_template("content/list.html", title="Devices", reportValues=self.getAllDeviceReports(), reportSchema=self.getReportSchema(), presetValues=self.getAllPresetValues(), actions=self.getActions(), systemInfo = self.getSystemInfo(), options=self.options, vars=self.tryHook("register_template_vars", "content/list.html"))
+        return render_template("content/list.html", title="Devices", reportValues=self.getAllDeviceReports(), reportSchema=self.getReportSchema(), presetValues=self.getAllPresetValues(), actions=self.getActions())
     
     def getAllPresetValues(self):
         # scan the preset directory and return value label pairs
@@ -201,7 +205,7 @@ class scute:
             session['userMessage'] = {"type": 'error', "message": "Invalid config detected for '<strong>" + currentConfig['local.friendlyName']  + " ("+ str(device) + ")</strong>'.<br />Please enter config manually, apply a preset or apply the default config via the SCRIPTS."}
     
 
-        return render_template("content/config.html", title="Device Configuration", schema=self.getConfigSchema(), device=device, current=currentConfig, systemInfo = self.getSystemInfo(), options=self.options, vars=self.tryHook("register_template_vars", "content/config.html"))
+        return render_template("content/config.html", title="Device Configuration", schema=self.getConfigSchema(), device=device, current=currentConfig)
 
     def applyPresetView(self):
         devices = request.args.getlist("devices[]")
@@ -241,10 +245,10 @@ class scute:
 
         presetSchema = self.filterOutFieldsWithBooleanAttribute(self.getConfigSchema(), "excludeFromPresets")
 
-        return render_template("content/applyPreset.html", title="Apply preset", schema=presetSchema, devices=devices, preset=preset, current = presetJSON, systemInfo = self.getSystemInfo(), options=self.options, vars=self.tryHook("register_template_vars", "content/applyPreset.html"))
+        return render_template("content/applyPreset.html", title="Apply preset", schema=presetSchema, devices=devices, preset=preset, current = presetJSON)
 
     def helpView(self):
-        return render_template("content/helpPage.html", title="Help", helpInfo=self.getHelpInfo(), systemInfo = self.getSystemInfo(), options=self.options, vars=self.tryHook("register_template_vars", "content/helpPage.html"))
+        return render_template("content/helpPage.html", title="Help", helpInfo=self.getHelpInfo())
     
 
 
@@ -341,7 +345,7 @@ class scute:
         
         presetSchema = self.filterOutFieldsWithBooleanAttribute(self.getConfigSchema(), "excludeFromPresets")
 
-        return render_template("content/presetsView.html", title="Preset Manager", presets=presetFiles, schema=presetSchema, current=prefill, systemInfo = self.getSystemInfo(), options=self.options, vars=self.tryHook("register_template_vars", "content/presetsView.html"))
+        return render_template("content/presetsView.html", title="Preset Manager", presets=presetFiles, schema=presetSchema, current=prefill)
 
 
 
@@ -387,7 +391,7 @@ class scute:
                 output = stderr
                 error = True
 
-        return render_template("content/script.html", title=scriptSchema["name"], script=scriptSchema, nextCommand = nextCommand, fileName=script, output=output, error = error, systemInfo = self.getSystemInfo(), options=self.options, vars=self.tryHook("register_template_vars", "content/script.html"))
+        return render_template("content/script.html", title=scriptSchema["name"], script=scriptSchema, nextCommand = nextCommand, fileName=script, output=output, error = error)
 
     def scriptsView(self):
 
@@ -456,7 +460,7 @@ class scute:
                 fileJSON["fileName"] = file
                 scripts.append(fileJSON)
 
-        return render_template("content/scriptsView.html", title="Scripts", scripts=scripts, systemInfo = self.getSystemInfo(), options=self.options, vars=self.tryHook("register_template_vars", "content/scriptsView.html"))
+        return render_template("content/scriptsView.html", title="Scripts", scripts=scripts)
 
     def expandJSON(self, json):
         # Expand a JSON object with dot based keys into a nested JSON

--- a/scute/__init__.py
+++ b/scute/__init__.py
@@ -18,6 +18,7 @@ scuteVersion =  '0.5.2' # for now this needs to match the version in setup.py
 class scute:
     hooks = {}
     def __init__(self, options, flaskServer):
+
         self.options = options
         self.server = flaskServer
         my_loader = jinja2.ChoiceLoader([
@@ -100,6 +101,13 @@ class scute:
     
     def registerHook(self, hookName, hookFunction):
         self.hooks[hookName] = hookFunction
+
+    def tryHook(self, hookName, *args):
+        try:
+            return self.hooks[hookName](*args)
+        except Exception as e:
+            print(e)
+            pass
     
     def getDevices(self):
         return self.hooks["get_devices"]()
@@ -129,12 +137,12 @@ class scute:
     def indexView(self):
 
         indexData = {"header": "Welcome To SCUTE", "content": "<a href='/list'>Scan For Devices</a>"}
-        return render_template("content/index.html", title="Welcome", indexData = indexData, systemInfo = self.getSystemInfo())
+        return render_template("content/index.html", title="Welcome", indexData = indexData, systemInfo = self.getSystemInfo(), options=self.options, vars=self.tryHook("register_template_vars", "content/index.html"))
 
 
     def deviceListView(self):
         
-        return render_template("content/list.html", title="Devices", reportValues=self.getAllDeviceReports(), reportSchema=self.getReportSchema(), presetValues=self.getAllPresetValues(), actions=self.getActions(), systemInfo = self.getSystemInfo())
+        return render_template("content/list.html", title="Devices", reportValues=self.getAllDeviceReports(), reportSchema=self.getReportSchema(), presetValues=self.getAllPresetValues(), actions=self.getActions(), systemInfo = self.getSystemInfo(), options=self.options, vars=self.tryHook("register_template_vars", "content/list.html"))
     
     def getAllPresetValues(self):
         # scan the preset directory and return value label pairs
@@ -193,7 +201,7 @@ class scute:
             session['userMessage'] = {"type": 'error', "message": "Invalid config detected for '<strong>" + currentConfig['local.friendlyName']  + " ("+ str(device) + ")</strong>'.<br />Please enter config manually, apply a preset or apply the default config via the SCRIPTS."}
     
 
-        return render_template("content/config.html", title="Device Configuration", schema=self.getConfigSchema(), device=device, current=currentConfig, systemInfo = self.getSystemInfo())
+        return render_template("content/config.html", title="Device Configuration", schema=self.getConfigSchema(), device=device, current=currentConfig, systemInfo = self.getSystemInfo(), options=self.options, vars=self.tryHook("register_template_vars", "content/config.html"))
 
     def applyPresetView(self):
         devices = request.args.getlist("devices[]")
@@ -233,10 +241,10 @@ class scute:
 
         presetSchema = self.filterOutFieldsWithBooleanAttribute(self.getConfigSchema(), "excludeFromPresets")
 
-        return render_template("content/applyPreset.html", title="Apply preset", schema=presetSchema, devices=devices, preset=preset, current = presetJSON, systemInfo = self.getSystemInfo())
+        return render_template("content/applyPreset.html", title="Apply preset", schema=presetSchema, devices=devices, preset=preset, current = presetJSON, systemInfo = self.getSystemInfo(), options=self.options, vars=self.tryHook("register_template_vars", "content/applyPreset.html"))
 
     def helpView(self):
-        return render_template("content/helpPage.html", title="Help", helpInfo=self.getHelpInfo(), systemInfo = self.getSystemInfo())
+        return render_template("content/helpPage.html", title="Help", helpInfo=self.getHelpInfo(), systemInfo = self.getSystemInfo(), options=self.options, vars=self.tryHook("register_template_vars", "content/helpPage.html"))
     
 
 
@@ -333,7 +341,7 @@ class scute:
         
         presetSchema = self.filterOutFieldsWithBooleanAttribute(self.getConfigSchema(), "excludeFromPresets")
 
-        return render_template("content/presetsView.html", title="Preset Manager", presets=presetFiles, schema=presetSchema, current=prefill, systemInfo = self.getSystemInfo())
+        return render_template("content/presetsView.html", title="Preset Manager", presets=presetFiles, schema=presetSchema, current=prefill, systemInfo = self.getSystemInfo(), options=self.options, vars=self.tryHook("register_template_vars", "content/presetsView.html"))
 
 
 
@@ -379,7 +387,7 @@ class scute:
                 output = stderr
                 error = True
 
-        return render_template("content/script.html", title=scriptSchema["name"], script=scriptSchema, nextCommand = nextCommand, fileName=script, output=output, error = error, systemInfo = self.getSystemInfo())
+        return render_template("content/script.html", title=scriptSchema["name"], script=scriptSchema, nextCommand = nextCommand, fileName=script, output=output, error = error, systemInfo = self.getSystemInfo(), options=self.options, vars=self.tryHook("register_template_vars", "content/script.html"))
 
     def scriptsView(self):
 
@@ -448,7 +456,7 @@ class scute:
                 fileJSON["fileName"] = file
                 scripts.append(fileJSON)
 
-        return render_template("content/scriptsView.html", title="Scripts", scripts=scripts, systemInfo = self.getSystemInfo())
+        return render_template("content/scriptsView.html", title="Scripts", scripts=scripts, systemInfo = self.getSystemInfo(), options=self.options, vars=self.tryHook("register_template_vars", "content/scriptsView.html"))
 
     def expandJSON(self, json):
         # Expand a JSON object with dot based keys into a nested JSON

--- a/scute/default_templates/layout/header.html
+++ b/scute/default_templates/layout/header.html
@@ -1,4 +1,2 @@
 {% include "layout/client_header.html" %}
 {% include "layout/menu.html" %}
-
-{{vars}}

--- a/scute/default_templates/layout/header.html
+++ b/scute/default_templates/layout/header.html
@@ -1,2 +1,4 @@
 {% include "layout/client_header.html" %}
 {% include "layout/menu.html" %}
+
+{{vars}}


### PR DESCRIPTION
1. Started by adding the `options` you pass in to scute at the start to an `options` template variable used on all the templates. So this is now available in every template. Not sure if this is a good thing in case this ever gets passwords and such put into it but I'll leave it in for now as things like app title, logo file etc could go in here.
2. Then made a get_template_vars hook for cases when you want something generated on the fly and loaded into each template. This is super powerful. I've updated the docs to explain this:

You may wish to add additional template variables to your templates. There is a `register_template_vars` hook for this purpose. It receives one parameter, the name of the template being rendered, and should return a dictionary. The dictionary returned will be placed in a `vars` object to use in your template.

For example:

```Python

def loadCustomVars(template):
    return {
        "currentTemplate": template,
        "time" : datetime.now().strftime("%H:%M:%S")
    }


```

3. When calling the hook I realsed we have lots of cases where we're calling a hook and doing a try catch in __init__.py to see if it exists. I've now created `tryHook()` which wraps this. Basically takes a hook name and any number of arguments. Returns nothing if the hook fails. Currently printing the error if one happens while we debug (this should be in a debug mode, another thing to do in the future). The only hook that currently uses this is `register_template_vars` and the old way of doing things still works too.

Not merging in until you confirm everything works but I think it'll be very useful for some extra template bits you're already doing like `get_system_info()` and making them a bit more flexible. I've left `get_system_info` in as it's probably quite a useful one but eventually it should be replaced by a general call to register_template_vars().

Comments / tweaks welcome.